### PR TITLE
[Seunghoon] 버튼 공통컴포넌트 UI 수정

### DIFF
--- a/app/_components/Button/Button.tsx
+++ b/app/_components/Button/Button.tsx
@@ -8,19 +8,20 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>, PropsWith
   bgColor: BgColor;
 }
 
-type ButtonSize = "large" | "small";
+type ButtonSize = "normal" | "small";
 
-type BgColor = "white" | "mainBlue" | "secondBlue";
+type BgColor = "mainBlue" | "secondBlue" | "white" | "stroke";
 
 const buttonClasses = {
-  large: "w-[557px] rounded py-3",
-  small: "w-[124px] rounded-lg py-3",
+  normal: "w-28 h-11 rounded-lg py-3 text-sm",
+  small: "w-[72px] h-11 rounded-lg py-3 text-sm",
 };
 
 const bgColorClasses: Record<BgColor, string> = {
-  white: "border border-[#1852FD] bg-white text-[#1852FD]",
-  mainBlue: "bg-[#0066DA] text-white",
-  secondBlue: "bg-[#EBECFF] text-[#1852FD]",
+  mainBlue: "bg-blue-500 text-white hover:bg-blue-600",
+  secondBlue: "bg-blue-100 text-blue-500",
+  white: "border border-gray-200 bg-white",
+  stroke: "text-blue-500",
 };
 
 function Button({ children, type = "button", buttonSize, bgColor, onClick, className, disabled }: ButtonProps) {


### PR DESCRIPTION
## 변경 사항
* 버튼 공통컴포넌트 UI 수정

## To. reviewers
* color값 수정해줬고 피그마 공통컴포넌트 시안에 맞게 UI 바꿔놨습니다.
* Btn_small에서 보시면 휴지통버튼은 width가 다른걸 볼 수 있는데, small props 넘겨주고 className에 알맞는 css 넣고 props로 넘겨주면 됩니다. twMerge 설정해놔서 바뀔겁니다.

## 이슈 번호

- https://github.com/Feed-B/frontend/issues/46

## 테스트 결과
![스크린샷 2024-06-10 오후 4 48 44](https://github.com/Feed-B/frontend/assets/74593476/dbc4d1e8-28ec-48ef-abb7-27259e0891bc)
![스크린샷 2024-06-10 오후 4 49 33](https://github.com/Feed-B/frontend/assets/74593476/09938b92-35bc-4e7a-a3e5-045a3de00b96)

