### PR TITLE
[YuKyoung] 프로필 수정 시, 헤더의 정보가 바로 반영되지 않던 문제 해결

### DIFF
--- a/app/_components/Header/HeaderDropDownBox.tsx
+++ b/app/_components/Header/HeaderDropDownBox.tsx
@@ -26,7 +26,7 @@ function HeaderDropDownBox({ handleLogout }: HeaderDropDownBoxProps) {
   const { data: userId } = useQuery(userQueryKeys.userId());
 
   const { data: userdata } = useQuery({
-    queryKey: ["profile", userId?.id],
+    queryKey: ["profile", userId?.id.toString()],
     queryFn: () => profileAPI.getUserData(Number(userId?.id)),
     enabled: !!userId,
   });

--- a/app/profile/[userId]/_components/MyPageContent.tsx
+++ b/app/profile/[userId]/_components/MyPageContent.tsx
@@ -2,7 +2,7 @@
 import { useParams } from "next/navigation";
 import { MouseEvent, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { profileAPI } from "@/app/_apis/ProfileAPI";
+import { userQueryKeys } from "@/app/_queryFactory/userQuery";
 import MypageProjectSection, { MyPageProjectListType } from "./MypageProjectSection";
 import MyPageCategory from "./MyPageCategory/MyPageCategory";
 import Profile from "./Profile/Profile";
@@ -11,12 +11,7 @@ function MyPageContent() {
   const { userId } = useParams();
   const [selectCategory, setSelectCategory] = useState<MyPageProjectListType>("myProject");
 
-  const { data: currentUserId } = useQuery({
-    queryKey: ["userId", "current"],
-    queryFn: async () => {
-      return await profileAPI.getCurrentUserId();
-    },
-  });
+  const { data: currentUserId } = useQuery(userQueryKeys.userId());
 
   if (!currentUserId) {
     return;


### PR DESCRIPTION
## 변경 사항
헤더의 드롭다운 쪽 userId를 string으로 바꿔서 타입을 맞춰줌
-> query의 key 타입이 맞아야 한다!

## To. reviewers
병현띠 컴포넌트여서 한 번 확인해주십쇼
-> 정의해두신 factory 가져다가 썼습니다.

## 테스트 결과
![프로필 변경 개선](https://github.com/Feed-B/frontend/assets/153581513/a4ed1712-25ae-4dfa-a11f-64e7546d6562)
