### PR TITLE
[YuKyoung] 프로필 페이지 반응형 구현

### DIFF
--- a/app/_components/ProjectList/ProjectCard/EmptyCard.tsx
+++ b/app/_components/ProjectList/ProjectCard/EmptyCard.tsx
@@ -8,7 +8,7 @@ function EmptyCard() {
   const { projectState } = useGetStack();
 
   return (
-    <div className="absolute left-1/2 top-40 flex -translate-x-1/2 flex-col items-center justify-center gap-6">
+    <div className="absolute left-1/2 top-10 flex -translate-x-1/2 flex-col items-center justify-center gap-6">
       <Image width={54} height={72} src={emptyFileIcon} alt="파일 없음" />
       <p className="text-xl font-semibold text-gray-700">
         {projectState.searchString ? (

--- a/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
+++ b/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
@@ -144,14 +144,14 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
                   value={aboutMeValue.value}
                   onChange={aboutMeValue.handleChangeValue}
                   id="introduction"
-                  className="h-[140px] w-[384px] resize-none rounded-lg border border-gray-200 px-2 py-3 text-sm text-gray-800 placeholder:text-sm 
+                  className="h-[150px] w-[384px] resize-none rounded-lg border border-gray-200 px-2 py-3 text-sm text-gray-800 placeholder:text-sm 
                 tbc:w-full
                 tbr:w-full
                 "
                   placeholder={"자신을 표현할 간단한 소개를 적어주세요(최대 150자)"}
                   maxLength={REFLY_ABOUT_ME_LENGTH}
                 />
-                <p className="absolute bottom-3 right-2 text-sm text-gray-500">
+                <p className="absolute bottom-3 right-3 text-sm text-gray-500">
                   {aboutMeValue.value.length} / {REFLY_ABOUT_ME_LENGTH}
                 </p>
               </div>

--- a/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
+++ b/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
@@ -20,6 +20,8 @@ interface EditProfileModalProps {
   profileData: UserDataType;
 }
 
+const REFLY_ABOUT_ME_LENGTH = 150;
+
 function EditProfileModal({ openModal, handleModalClose, profileData }: EditProfileModalProps) {
   const queryClient = useQueryClient();
 
@@ -137,16 +139,22 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
               <label htmlFor="introduction" className="text-base font-bold text-gray-900">
                 {MY_PAGE_TEXT.INTRODUCTION}
               </label>
-              <textarea
-                value={aboutMeValue.value}
-                onChange={aboutMeValue.handleChangeValue}
-                id="introduction"
-                className="h-[140px] w-[384px] resize-none rounded-lg border border-gray-200 px-2 py-3 text-sm text-gray-800 placeholder:text-sm 
+              <div className="relative">
+                <textarea
+                  value={aboutMeValue.value}
+                  onChange={aboutMeValue.handleChangeValue}
+                  id="introduction"
+                  className="h-[140px] w-[384px] resize-none rounded-lg border border-gray-200 px-2 py-3 text-sm text-gray-800 placeholder:text-sm 
                 tbc:w-full
                 tbr:w-full
                 "
-                placeholder={"자신을 표현할 간단한 소개를 적어주세요(최대 150자)"}
-              />
+                  placeholder={"자신을 표현할 간단한 소개를 적어주세요(최대 150자)"}
+                  maxLength={REFLY_ABOUT_ME_LENGTH}
+                />
+                <p className="absolute bottom-3 right-2 text-sm text-gray-500">
+                  {aboutMeValue.value.length} / {REFLY_ABOUT_ME_LENGTH}
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
+++ b/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
@@ -80,13 +80,18 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
   }, []);
 
   return (
-    <Modal openModal={openModal} handleModalClose={handleModalClose}>
+    <Modal
+      openModal={openModal}
+      handleModalClose={handleModalClose}
+      className="mb:fixed mb:h-screen mb:w-screen mb:overflow-x-hidden mb:overflow-y-scroll mb:rounded-none mb:bg-white">
       <form onSubmit={handleCompletedProfile} className="flex flex-col items-center gap-8">
         <div className="flex flex-col items-center justify-center gap-8 px-12 pt-[90px]">
-          <div className="flex gap-16">
-            <div className="relative flex flex-col items-center gap-5">
-              <DeleteImageButton onClick={handleRemoveImage} className="absolute right-0" />
-              <ProfileImage imageUrl={image ? image : "default"} className="h-[124px] w-[124px]" />
+          <div className="flex gap-16 mb:flex-col mb:gap-5">
+            <div className="flex flex-col items-center gap-5">
+              <div className="relative inline-block">
+                <DeleteImageButton onClick={handleRemoveImage} className="absolute right-0" />
+                <ProfileImage imageUrl={image ? image : "default"} className="h-[124px] w-[124px]" />
+              </div>
               <Button type="button" bgColor="stroke" buttonSize="normal" onClick={handleSelectImageClick}>
                 {MY_PAGE_TEXT.EDIT_IMAGE}
               </Button>
@@ -123,8 +128,13 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
             </div>
           </div>
         </div>
-        <div className="flex gap-4 pb-10">
-          <Button onClick={handleModalClose} type="button" buttonSize="normal" bgColor="white">
+        <div className="flex gap-4 pb-10 mb:pb-0">
+          <Button
+            onClick={handleModalClose}
+            type="button"
+            buttonSize="normal"
+            bgColor="white"
+            className="flex items-center justify-center">
             {MY_PAGE_TEXT.CANCEL}
           </Button>
           <Button
@@ -132,7 +142,7 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
             type="button"
             buttonSize="normal"
             bgColor="yellow"
-            className="bg-yellow-500 font-semibold">
+            className="flex items-center justify-center bg-yellow-500 font-semibold">
             {MY_PAGE_TEXT.COMPLETE_EDIT}
           </Button>
         </div>

--- a/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
+++ b/app/profile/[userId]/_components/EditProfileModal/EditProfileModal.tsx
@@ -83,11 +83,29 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
     <Modal
       openModal={openModal}
       handleModalClose={handleModalClose}
-      className="mb:fixed mb:h-screen mb:w-screen mb:overflow-x-hidden mb:overflow-y-scroll mb:rounded-none mb:bg-white">
-      <form onSubmit={handleCompletedProfile} className="flex flex-col items-center gap-8">
-        <div className="flex flex-col items-center justify-center gap-8 px-12 pt-[90px]">
-          <div className="flex gap-16 mb:flex-col mb:gap-5">
-            <div className="flex flex-col items-center gap-5">
+      className="overflow-y-scroll 
+      mb:fixed mb:h-screen mb:w-screen mb:overflow-x-hidden mb:overflow-y-scroll mb:rounded-none 
+      tbc:fixed tbc:h-screen tbc:w-screen tbc:overflow-x-hidden tbc:overflow-y-scroll tbc:rounded-none
+      tbr:fixed tbr:h-screen tbr:w-screen tbr:overflow-x-hidden tbr:overflow-y-scroll tbr:rounded-none
+      ">
+      <form
+        onSubmit={handleCompletedProfile}
+        className="flex flex-col items-center gap-8 
+        tbc:h-full tbc:justify-between
+        tbr:h-full tbr:justify-between
+        ">
+        <div
+          className="flex flex-col items-center justify-center gap-8 px-12 pt-[90px] 
+        tbc:w-full
+        tbr:w-full
+        ">
+          <div
+            className="flex gap-16 
+          mb:flex-col mb:gap-5 
+          tbc:w-[95%] tbc:flex-col tbc:justify-start tbc:gap-5
+          tbr:w-[95%] tbr:flex-col tbr:justify-start tbr:gap-5
+          ">
+            <div className="flex flex-col items-center">
               <div className="relative inline-block">
                 <DeleteImageButton onClick={handleRemoveImage} className="absolute right-0" />
                 <ProfileImage imageUrl={image ? image : "default"} className="h-[124px] w-[124px]" />
@@ -112,6 +130,7 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
                 type="text"
                 placeholder={profileData?.nickName}
                 title="닉네임"
+                className="tbc:w-full tbr:w-full"
               />
               <p className="text-base font-bold text-gray-900">{MY_PAGE_TEXT.JOB}</p>
               <DropDownBox dataType="job" handleInputChange={handleSetValue} inputWidth={"w-full"} />
@@ -122,7 +141,10 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
                 value={aboutMeValue.value}
                 onChange={aboutMeValue.handleChangeValue}
                 id="introduction"
-                className="h-[140px] w-[384px] resize-none rounded-lg border border-gray-200 px-2 py-3 text-sm text-gray-800 placeholder:text-sm"
+                className="h-[140px] w-[384px] resize-none rounded-lg border border-gray-200 px-2 py-3 text-sm text-gray-800 placeholder:text-sm 
+                tbc:w-full
+                tbr:w-full
+                "
                 placeholder={"자신을 표현할 간단한 소개를 적어주세요(최대 150자)"}
               />
             </div>
@@ -141,8 +163,8 @@ function EditProfileModal({ openModal, handleModalClose, profileData }: EditProf
             onClick={handleCompletedProfile}
             type="button"
             buttonSize="normal"
-            bgColor="yellow"
-            className="flex items-center justify-center bg-yellow-500 font-semibold">
+            bgColor="mainBlue"
+            className="flex items-center justify-center text-white">
             {MY_PAGE_TEXT.COMPLETE_EDIT}
           </Button>
         </div>

--- a/app/profile/[userId]/_components/MyPageCategory/MyPageCategory.tsx
+++ b/app/profile/[userId]/_components/MyPageCategory/MyPageCategory.tsx
@@ -16,7 +16,7 @@ interface MyPageCategory {
 function MyPageCategory({ selectCategory, handleSelectCategory, isMyPage }: MyPageCategory) {
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-lg font-bold text-gray-900">{MY_PAGE_TEXT.MY_PAGE}</div>
+      <div className="text-lg font-bold text-gray-900 mb:hidden">{MY_PAGE_TEXT.MY_PAGE}</div>
       <ProjectCategoryButton
         onClick={handleSelectCategory}
         id={"myProject"}

--- a/app/profile/[userId]/_components/MyPageCategory/MyPageCategory.tsx
+++ b/app/profile/[userId]/_components/MyPageCategory/MyPageCategory.tsx
@@ -16,7 +16,7 @@ interface MyPageCategory {
 function MyPageCategory({ selectCategory, handleSelectCategory, isMyPage }: MyPageCategory) {
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-lg font-bold text-gray-900 mb:hidden">{MY_PAGE_TEXT.MY_PAGE}</div>
+      <div className="text-lg font-bold text-gray-900 mb:hidden tbc:hidden tbr:hidden">{MY_PAGE_TEXT.MY_PAGE}</div>
       <ProjectCategoryButton
         onClick={handleSelectCategory}
         id={"myProject"}

--- a/app/profile/[userId]/_components/MyPageCategory/MyPageCategory.tsx
+++ b/app/profile/[userId]/_components/MyPageCategory/MyPageCategory.tsx
@@ -16,7 +16,7 @@ interface MyPageCategory {
 function MyPageCategory({ selectCategory, handleSelectCategory, isMyPage }: MyPageCategory) {
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-lg font-bold text-gray-900 mb:hidden tbc:hidden tbr:hidden">{MY_PAGE_TEXT.MY_PAGE}</div>
+      <div className="hidden text-lg font-bold text-gray-900 pc:block">{MY_PAGE_TEXT.MY_PAGE}</div>
       <ProjectCategoryButton
         onClick={handleSelectCategory}
         id={"myProject"}

--- a/app/profile/[userId]/_components/MyPageContent.tsx
+++ b/app/profile/[userId]/_components/MyPageContent.tsx
@@ -23,8 +23,16 @@ function MyPageContent() {
   const isMyPage = currentUserId.id === Number(userId) ? true : false;
 
   return (
-    <main className="mx-auto mt-[64px] grid max-w-[1200px] grid-cols-[180px_1fr] grid-rows-2 gap-x-11 gap-y-8 mb:mt-4 mb:grid-cols-1 mb:grid-rows-[minmax(120px,_1fr)_88px_1fr] mb:gap-y-6 mb:p-5">
-      <div className="col-span-1 row-span-2 mb:row-start-2 mb:row-end-3">
+    <main
+      className="mx-auto mt-[64px] grid max-w-[1200px] grid-cols-[180px_1fr] grid-rows-[186px_1fr] gap-x-11 gap-y-8 
+      mb:mt-4 mb:grid-cols-1 mb:grid-rows-[minmax(120px,_1fr)_88px_1fr] mb:gap-y-6 mb:p-5 
+    tbc:mt-4 tbc:grid-cols-1 tbc:grid-rows-[180px_88px_1fr] tbc:gap-y-10 tbc:p-5
+    tbr:mt-4 tbr:grid-cols-1 tbr:grid-rows-[180px_88px_1fr] tbr:gap-y-10 tbr:p-5">
+      <div
+        className="col-span-1 row-span-2 
+        mb:row-start-2 mb:row-end-3 
+        tbc:row-start-2 tbc:row-end-3
+        tbr:row-start-2 tbr:row-end-3">
         <MyPageCategory
           isMyPage={isMyPage}
           selectCategory={selectCategory}

--- a/app/profile/[userId]/_components/MyPageContent.tsx
+++ b/app/profile/[userId]/_components/MyPageContent.tsx
@@ -24,15 +24,12 @@ function MyPageContent() {
 
   return (
     <main
-      className="mx-auto mt-[64px] grid max-w-[1200px] grid-cols-[180px_1fr] grid-rows-[186px_1fr] gap-x-11 gap-y-8 
-      mb:mt-4 mb:grid-cols-1 mb:grid-rows-[minmax(120px,_1fr)_88px_1fr] mb:gap-y-6 mb:p-5 
-    tbc:mt-4 tbc:grid-cols-1 tbc:grid-rows-[180px_88px_1fr] tbc:gap-y-10 tbc:p-5
-    tbr:mt-4 tbr:grid-cols-1 tbr:grid-rows-[180px_88px_1fr] tbr:gap-y-10 tbr:p-5">
-      <div
-        className="col-span-1 row-span-2 
-        mb:row-start-2 mb:row-end-3 
-        tbc:row-start-2 tbc:row-end-3
-        tbr:row-start-2 tbr:row-end-3">
+      className="mx-auto mt-4 grid grid-cols-1 grid-rows-[180px_88px_1fr] gap-x-11 gap-y-10 px-8 
+      mb:grid-rows-[minmax(120px,_1fr)_88px_1fr] mb:gap-y-6 mb:p-5 
+      tbr:p-5 
+      pc:mt-[64px] pc:max-w-[1200px] pc:grid-cols-[180px_1fr] pc:grid-rows-[186px_1fr] pc:gap-y-8
+    ">
+      <div className="row-start-2 row-end-3 pc:col-span-1 pc:row-span-2">
         <MyPageCategory
           isMyPage={isMyPage}
           selectCategory={selectCategory}

--- a/app/profile/[userId]/_components/MyPageContent.tsx
+++ b/app/profile/[userId]/_components/MyPageContent.tsx
@@ -23,16 +23,18 @@ function MyPageContent() {
   const isMyPage = currentUserId.id === Number(userId) ? true : false;
 
   return (
-    <main className="mb-20 ml-[50%] mt-10 flex w-[1200px] -translate-x-1/2 gap-11 gap-y-16">
-      <div className="w-[180px]">
+    <main className="mx-auto mt-[64px] grid max-w-[1200px] grid-cols-[180px_1fr] grid-rows-2 gap-x-11 gap-y-8 mb:mt-4 mb:grid-cols-1 mb:grid-rows-3 mb:gap-y-6 mb:p-5">
+      <div className="col-span-1 row-span-2 mb:row-start-2 mb:row-end-3">
         <MyPageCategory
           isMyPage={isMyPage}
           selectCategory={selectCategory}
           handleSelectCategory={handleSelectCategory}
         />
       </div>
-      <div className="flex w-[976px] flex-col gap-8">
+      <div className="col-span-1">
         <Profile isMyPage={isMyPage} />
+      </div>
+      <div className="col-span-1 mb:-mt-10">
         <MypageProjectSection isMyPage={isMyPage} projectType={selectCategory} userId={Number(userId)} />
       </div>
     </main>

--- a/app/profile/[userId]/_components/MyPageContent.tsx
+++ b/app/profile/[userId]/_components/MyPageContent.tsx
@@ -23,7 +23,7 @@ function MyPageContent() {
   const isMyPage = currentUserId.id === Number(userId) ? true : false;
 
   return (
-    <main className="mx-auto mt-[64px] grid max-w-[1200px] grid-cols-[180px_1fr] grid-rows-2 gap-x-11 gap-y-8 mb:mt-4 mb:grid-cols-1 mb:grid-rows-3 mb:gap-y-6 mb:p-5">
+    <main className="mx-auto mt-[64px] grid max-w-[1200px] grid-cols-[180px_1fr] grid-rows-2 gap-x-11 gap-y-8 mb:mt-4 mb:grid-cols-1 mb:grid-rows-[minmax(120px,_1fr)_88px_1fr] mb:gap-y-6 mb:p-5">
       <div className="col-span-1 row-span-2 mb:row-start-2 mb:row-end-3">
         <MyPageCategory
           isMyPage={isMyPage}
@@ -34,7 +34,7 @@ function MyPageContent() {
       <div className="col-span-1">
         <Profile isMyPage={isMyPage} />
       </div>
-      <div className="col-span-1 mb:-mt-10">
+      <div className="col-span-1">
         <MypageProjectSection isMyPage={isMyPage} projectType={selectCategory} userId={Number(userId)} />
       </div>
     </main>

--- a/app/profile/[userId]/_components/MyPageContent.tsx
+++ b/app/profile/[userId]/_components/MyPageContent.tsx
@@ -24,10 +24,10 @@ function MyPageContent() {
 
   return (
     <main
-      className="mx-auto mt-4 grid grid-cols-1 grid-rows-[180px_88px_1fr] gap-x-11 gap-y-10 px-8 
-      mb:grid-rows-[minmax(120px,_1fr)_88px_1fr] mb:gap-y-6 mb:p-5 
+      className="mx-auto mt-4 grid grid-cols-1 grid-rows-[fit-content_88px_1fr] gap-x-11 gap-y-10 px-8 
+      mb:gap-y-6 mb:p-5
       tbr:p-5 
-      pc:mt-[64px] pc:max-w-[1200px] pc:grid-cols-[180px_1fr] pc:grid-rows-[186px_1fr] pc:gap-y-8
+      pc:mt-[64px] pc:max-w-[1200px] pc:grid-cols-[180px_1fr] pc:grid-rows-[fit-content_1fr] pc:gap-y-8
     ">
       <div className="row-start-2 row-end-3 pc:col-span-1 pc:row-span-2">
         <MyPageCategory

--- a/app/profile/[userId]/_components/MypageProjectSection.tsx
+++ b/app/profile/[userId]/_components/MypageProjectSection.tsx
@@ -51,7 +51,7 @@ function MypageProjectSection({
   };
 
   return (
-    <section>
+    <section className="flex flex-col">
       <h3 className="mb-4 text-lg font-semibold leading-relaxed text-gray-900">
         {listTitle(isMyPage, projectType)}
         <span className="ml-2.5">({data?.pages[0].customPageable.totalElements})</span>

--- a/app/profile/[userId]/_components/Profile/Profile.tsx
+++ b/app/profile/[userId]/_components/Profile/Profile.tsx
@@ -27,17 +27,28 @@ function Profile({ isMyPage }: { isMyPage: boolean }) {
   return (
     <>
       {isOpen && <EditProfileModal profileData={userProfileData} openModal={isOpen} handleModalClose={toggleState} />}
-      <form className="relative flex items-center justify-start gap-8 rounded-lg border border-solid border-gray-200 p-8 mb:gap-2 mb:pt-3">
+      <form
+        className="relative flex items-center justify-start gap-8 rounded-lg border border-solid border-gray-200 p-8 
+      mb:gap-2 mb:pt-3">
         <ProfileImage
           imageUrl={userProfileData?.imageUrl ? userProfileData.imageUrl : "default"}
-          className="relative h-[120px] w-[120px] flex-shrink-0 mb:h-[66px] mb:w-[66px]"
+          className="relative h-[120px] w-[120px] flex-shrink-0 
+          mb:h-[66px] mb:w-[66px]"
         />
         <div className="mt-2.5 flex flex-col gap-3">
-          <div className="flex items-center gap-4 mb:gap-1">
+          <div
+            className="flex items-center gap-4 
+          mb:gap-1">
             <div className="text-lg font-semibold text-gray-900">{userProfileData?.nickName}</div>
             <JobBadge job={JOB_CATEGORIES_KR[userProfileData.job] as JobCategoriesType} />
           </div>
-          <p className="w-[85%] text-sm text-gray-700 mb:w-auto">{userProfileData?.aboutMe}</p>
+          <p
+            className="w-[81%] text-sm text-gray-700 
+          mb:w-auto 
+          tbc:w-auto 
+          tbr:w-auto">
+            {userProfileData?.aboutMe}
+          </p>
         </div>
         {isMyPage && (
           <Button
@@ -45,7 +56,10 @@ function Profile({ isMyPage }: { isMyPage: boolean }) {
             type="button"
             bgColor="stroke"
             buttonSize="normal"
-            className="absolute bottom-8 right-8 w-28 border-none text-blue-500 mb:-right-1.5 mb:top-3.5 mb:bg-transparent">
+            className="tbc:p-x-1 absolute bottom-8 right-8 w-28 border-none text-blue-500 
+            mb:-right-1.5 mb:top-3.5 mb:bg-transparent 
+            tbc:right-9 tbc:top-8 tbc:w-[84px] tbc:px-1
+            tbr:right-9 tbr:top-8 tbr:w-[84px] tbr:px-1">
             {MY_PAGE_TEXT.EDIT_PROFILE}
           </Button>
         )}

--- a/app/profile/[userId]/_components/Profile/Profile.tsx
+++ b/app/profile/[userId]/_components/Profile/Profile.tsx
@@ -27,17 +27,17 @@ function Profile({ isMyPage }: { isMyPage: boolean }) {
   return (
     <>
       {isOpen && <EditProfileModal profileData={userProfileData} openModal={isOpen} handleModalClose={toggleState} />}
-      <form className="relative flex items-center justify-start gap-8 rounded-lg border border-solid border-gray-200 p-8 px-4 pb-4 mb:gap-2 mb:pt-3">
+      <form className="relative flex items-center justify-start gap-8 rounded-lg border border-solid border-gray-200 p-8 mb:gap-2 mb:pt-3">
         <ProfileImage
           imageUrl={userProfileData?.imageUrl ? userProfileData.imageUrl : "default"}
-          className="relative h-[120px] w-[120px] mb:h-[66px] mb:w-[66px]"
+          className="relative h-[120px] w-[120px] flex-shrink-0 mb:h-[66px] mb:w-[66px]"
         />
         <div className="mt-2.5 flex flex-col gap-3">
           <div className="flex items-center gap-4 mb:gap-1">
             <div className="text-lg font-semibold text-gray-900">{userProfileData?.nickName}</div>
             <JobBadge job={JOB_CATEGORIES_KR[userProfileData.job] as JobCategoriesType} />
           </div>
-          <div className="text-sm text-gray-700">{userProfileData?.aboutMe}</div>
+          <p className="w-[85%] text-sm text-gray-700 mb:w-auto">{userProfileData?.aboutMe}</p>
         </div>
         {isMyPage && (
           <Button

--- a/app/profile/[userId]/_components/Profile/Profile.tsx
+++ b/app/profile/[userId]/_components/Profile/Profile.tsx
@@ -27,15 +27,13 @@ function Profile({ isMyPage }: { isMyPage: boolean }) {
   return (
     <>
       {isOpen && <EditProfileModal profileData={userProfileData} openModal={isOpen} handleModalClose={toggleState} />}
-      <form className="relative flex items-start justify-start gap-8 rounded-lg border border-solid border-gray-200 p-8">
-        <div className="relative">
-          <ProfileImage
-            imageUrl={userProfileData?.imageUrl ? userProfileData.imageUrl : "default"}
-            className="h-[120px] w-[120px]"
-          />
-        </div>
+      <form className="relative flex items-center justify-start gap-8 rounded-lg border border-solid border-gray-200 p-8 px-4 pb-4 mb:gap-2 mb:pt-3">
+        <ProfileImage
+          imageUrl={userProfileData?.imageUrl ? userProfileData.imageUrl : "default"}
+          className="relative h-[120px] w-[120px] mb:h-[66px] mb:w-[66px]"
+        />
         <div className="mt-2.5 flex flex-col gap-3">
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 mb:gap-1">
             <div className="text-lg font-semibold text-gray-900">{userProfileData?.nickName}</div>
             <JobBadge job={JOB_CATEGORIES_KR[userProfileData.job] as JobCategoriesType} />
           </div>
@@ -47,7 +45,7 @@ function Profile({ isMyPage }: { isMyPage: boolean }) {
             type="button"
             bgColor="stroke"
             buttonSize="normal"
-            className="absolute bottom-8 right-8 w-28">
+            className="absolute bottom-8 right-8 w-28 border-none text-blue-500 mb:-right-1.5 mb:top-3.5 mb:bg-transparent">
             {MY_PAGE_TEXT.EDIT_PROFILE}
           </Button>
         )}


### PR DESCRIPTION
## 변경 사항
프로필 페이지 반응형 구현했습니다.

## To. reviewers
- 소개글이 많은 경우 프로필 수정 버튼을 침범하지 못하도록 했습니다 !
- 프로젝트 리스트 부분은 병현띠가 먼저 작업했길래 병현띠꺼 머지되면 다시 확인 하겠습니다
- 모바일 정도로 줄어들었을 때 프로필 수정 버튼과 직무 태그가 겹치는데, 작아졌을 때 버튼 텍스트가 "수정" 버튼만 남는 건 어떤지 디자이너님께 물어본 상태입니다 !
- 소개글 글자수 제한 걸어두었습니다

## 이슈 번호
- #215

## 테스트 결과
![프로필 페이지 반응형](https://github.com/user-attachments/assets/ffe17329-a8cd-42f3-aee4-69092a5356ba)
